### PR TITLE
#28: create cron job with jira heathcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update --fix-missing \
     build-essential \
     libpq-dev \
     wget curl vim locales zip unzip apt-utils \
+    cron \
     && rm -rf /var/lib/apt/lists/* \
     && pip install --no-cache-dir uWSGI==2.0.25.1 uwsgitop==0.12 uv
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       dockerfile: Dockerfile
     env_file:
       - .env
-    command: bash -c "uv venv && source .venv/bin/activate && uv pip install --no-cache -r requirements-dev.txt && python manage.py migrate --noinput && python manage.py collectstatic --noinput && python manage.py runserver 0.0.0.0:8000"
+    command: bash -c "uv venv --python $(which python3) && source .venv/bin/activate && uv pip install --no-cache -r requirements-dev.txt && python manage.py migrate --noinput && python manage.py collectstatic --noinput && service cron start && python manage.py crontab remove && python manage.py crontab add && python manage.py runserver 0.0.0.0:8000"
 
     ports:
       - 8000:8000

--- a/documentacao/tecnica/cron_jobs.md
+++ b/documentacao/tecnica/cron_jobs.md
@@ -1,0 +1,155 @@
+# Cron Jobs no Sistema Jiboia
+
+Este documento descreve a implementação e gerenciamento de cron jobs no sistema Jiboia, com foco inicial no healthcheck da API do Jira.
+
+## Visão Geral
+
+O sistema utiliza cron jobs para executar tarefas agendadas automaticamente. Atualmente, implementamos:
+
+1. **Healthcheck da API do Jira** - Executa diariamente à meia-noite para verificar se a API do Jira está acessível, garantindo que a integração continua funcionando corretamente.
+
+Novos cron jobs podem ser adicionados seguindo a mesma estrutura e padrões descritos neste documento.
+
+## Arquitetura
+
+A implementação utiliza o pacote `django-crontab`, que integra os cron jobs do sistema operacional com o Django. A arquitetura é composta por:
+
+1. **Serviços** - Classes que encapsulam a lógica de negócios e chamadas externas, localizados em `jiboia/core/service/`.
+2. **Funções de Cron** - Funções que são executadas pelo agendador, localizadas em `jiboia/core/cron.py`.
+3. **Configuração** - Definição dos agendamentos no `settings.py` do Django.
+
+## Configuração
+
+### Variáveis de Ambiente
+
+Para os cron jobs existentes, as seguintes variáveis de ambiente são necessárias no arquivo `.env`:
+
+```
+# Configurações do Jira (para o healthcheck)
+JIRA_API_URL=https://necto.atlassian.net
+JIRA_API_EMAIL=seu-email@exemplo.com
+JIRA_API_TOKEN=seu-token-api
+```
+
+Novos cron jobs podem requerer suas próprias variáveis de ambiente, que devem ser documentadas conforme implementadas.
+
+### Configuração do Django
+
+Os cron jobs são configurados no `settings.py` seguindo este formato:
+
+```python
+CRONJOBS = [
+    # Formato: ('minuto hora dia_do_mês mês dia_da_semana', 'caminho.para.função', '>> /caminho/para/log 2>&1')
+    
+    # Healthcheck diário do Jira (meia-noite)
+    ('0 0 * * *', 'jiboia.core.cron.jira_healthcheck', '>> /tmp/jira_healthcheck.log 2>&1'),
+    
+    # Exemplo de formato para novos cron jobs
+    # ('* * * * *', 'jiboia.core.cron.nova_funcao', '>> /tmp/nova_funcao.log 2>&1'),
+]
+```
+
+## Gestão dos Cron Jobs
+
+### Comandos Disponíveis
+
+Os seguintes comandos estão disponíveis para gerenciar todos os cron jobs:
+
+```bash
+# Adicionar os cron jobs ao sistema
+python manage.py crontab add
+
+# Mostrar os cron jobs configurados
+python manage.py crontab show
+
+# Remover os cron jobs do sistema
+python manage.py crontab remove
+
+# Executar um cron job específico manualmente (para testes)
+python manage.py crontab run <hash>
+```
+
+O `<hash>` é um identificador único gerado para cada cron job. Para obter o hash correto, execute `python manage.py crontab show` e note o identificador entre parênteses.
+
+Exemplo para o healthcheck do Jira:
+```bash
+python manage.py crontab run 2dfdc8fe48583985868ea44dc3c84b58
+```
+
+### Logs
+
+Cada cron job possui seu próprio arquivo de log, definido na configuração CRONJOBS. Por exemplo:
+- Healthcheck do Jira: `/tmp/jira_healthcheck.log`
+
+Além disso, os logs também aparecem nos logs padrão do Django.
+
+## Funcionamento no Docker
+
+### Inicialização Automática
+
+No ambiente Docker, os cron jobs são configurados automaticamente na inicialização do container através do comando definido no `docker-compose.yml`:
+
+```bash
+service cron start && python manage.py crontab remove && python manage.py crontab add
+```
+
+Esta sequência:
+1. Inicia o serviço cron no container
+2. Remove quaisquer configurações antigas
+3. Registra todos os cron jobs definidos em settings.py
+
+### Desenvolvimento e Manutenção
+
+Ao implementar novos cron jobs ou modificar existentes:
+
+1. Adicione a função no arquivo `jiboia/core/cron.py`
+2. Registre o agendamento em `settings.py` na lista CRONJOBS
+3. Reinicie o container ou execute manualmente:
+   ```bash
+   python manage.py crontab remove
+   python manage.py crontab add
+   ```
+
+## Implementações Atuais
+
+### Healthcheck da API do Jira
+
+- **Função**: `jiboia.core.cron.jira_healthcheck`
+- **Agendamento**: Diariamente à meia-noite (`0 0 * * *`)
+- **Log**: `/tmp/jira_healthcheck.log`
+- **Descrição**: Verifica se o endpoint de projetos da API do Jira está acessível
+- **Hash atual**: `2dfdc8fe48583985868ea44dc3c84b58`
+
+## Solução de Problemas
+
+Se os cron jobs não estiverem funcionando como esperado, verifique:
+
+1. Se o serviço cron está em execução no container:
+   ```bash
+   service cron status
+   ```
+
+2. Se os cron jobs estão registrados corretamente:
+   ```bash
+   python manage.py crontab show
+   ```
+
+3. Se as variáveis de ambiente necessárias estão configuradas corretamente.
+
+4. Se há permissões de escrita nos diretórios de logs.
+
+5. Verifique os logs específicos de cada cron job.
+
+6. Para problemas com um cron job específico, teste-o manualmente usando o comando `run` com o hash apropriado.
+
+**Nota importante**: O hash de cada job é gerado pelo django-crontab com base na sua definição no settings.py. Se você modificar a definição, o hash mudará e precisará ser atualizado para testes manuais. O hash correto pode ser sempre identificado executando `python manage.py crontab show`.
+
+## Expandindo o Sistema de Cron Jobs
+
+Para adicionar novos cron jobs ao sistema:
+
+1. Implemente a lógica de negócios em um serviço apropriado em `jiboia/core/service/`
+2. Crie uma função de cron em `jiboia/core/cron.py` que utilize o serviço
+3. Adicione o agendamento na lista CRONJOBS no settings.py
+4. Defina as variáveis de ambiente necessárias
+5. Atualize esta documentação com os detalhes do novo cron job

--- a/jiboia/core/cron.py
+++ b/jiboia/core/cron.py
@@ -1,0 +1,27 @@
+import logging
+from datetime import datetime
+from .service.jira_svc import JiraService
+
+logger = logging.getLogger(__name__)
+
+def jira_healthcheck():
+    """
+    Função executada pelo cron para fazer o healthcheck da API do Jira.
+    Esta função é chamada pelo django-crontab de acordo com o agendamento configurado
+    no settings.py. Ela registra o resultado em logs e pode ser expandida para
+    enviar alertas em caso de falha.
+    """
+    start_time = datetime.now()
+    logger.info(f"[CRON] Iniciando healthcheck da API do Jira em {start_time.strftime('%Y-%m-%d %H:%M:%S')}")
+    
+    success, message = JiraService.healthcheck()
+    
+    end_time = datetime.now()
+    duration = (end_time - start_time).total_seconds()
+    
+    if success:
+        logger.info(f"[CRON] Healthcheck da API do Jira concluído com sucesso em {duration:.2f}s: {message}")
+    else:
+        logger.error(f"[CRON] Healthcheck da API do Jira falhou após {duration:.2f}s: {message}")
+    
+    return success

--- a/jiboia/core/cron.py
+++ b/jiboia/core/cron.py
@@ -6,13 +6,12 @@ logger = logging.getLogger(__name__)
 
 def jira_healthcheck():
     """
-    Função executada pelo cron para fazer o healthcheck da API do Jira.
-    Esta função é chamada pelo django-crontab de acordo com o agendamento configurado
-    no settings.py. Ela registra o resultado em logs e pode ser expandida para
-    enviar alertas em caso de falha.
+    Function executed by cron to perform a healthcheck on the Jira API.
+    This function is called by django-crontab according to the schedule configured
+    in settings.py. It logs the result and can be expanded to send alerts in case of failure.
     """
     start_time = datetime.now()
-    logger.info(f"[CRON] Iniciando healthcheck da API do Jira em {start_time.strftime('%Y-%m-%d %H:%M:%S')}")
+    logger.info(f"[CRON] Starting Jira API healthcheck at {start_time.strftime('%Y-%m-%d %H:%M:%S')}")
     
     success, message = JiraService.healthcheck()
     
@@ -20,8 +19,8 @@ def jira_healthcheck():
     duration = (end_time - start_time).total_seconds()
     
     if success:
-        logger.info(f"[CRON] Healthcheck da API do Jira concluído com sucesso em {duration:.2f}s: {message}")
+        logger.info(f"[CRON] Jira API healthcheck completed successfully in {duration:.2f}s: {message}")
     else:
-        logger.error(f"[CRON] Healthcheck da API do Jira falhou após {duration:.2f}s: {message}")
+        logger.error(f"[CRON] Jira API healthcheck failed after {duration:.2f}s: {message}")
     
     return success

--- a/jiboia/core/service/jira_svc.py
+++ b/jiboia/core/service/jira_svc.py
@@ -1,0 +1,44 @@
+import logging
+import requests
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+class JiraService:
+    """Serviço para interação com a API do Jira"""
+    
+    @staticmethod
+    def healthcheck():
+        """
+        Realiza um healthcheck na API do Jira verificando o endpoint de projetos.
+        
+        Returns:
+            tuple: (success, message) onde success é um booleano indicando se o healthcheck foi bem-sucedido
+                   e message é uma string com detalhes adicionais.
+        """
+        email = settings.JIRA_API_EMAIL
+        token = settings.JIRA_API_TOKEN
+        base_url = settings.JIRA_API_URL
+        
+        url = f"{base_url}/rest/api/3/project"
+        
+        logger.info(f"Realizando healthcheck na API do Jira: {url}")
+        
+        try:
+            response = requests.get(
+                url, 
+                auth=(email, token),
+                headers={"Accept": "application/json"}
+            )
+            
+            if response.status_code == 200:
+                projects_count = len(response.json())
+                logger.info(f"Jira API healthcheck bem-sucedido. {projects_count} projetos encontrados.")
+                return True, f"OK - {projects_count} projetos encontrados"
+            else:
+                logger.error(f"Jira API healthcheck falhou com status {response.status_code}: {response.text}")
+                return False, f"Falhou com status {response.status_code}"
+                
+        except Exception as e:
+            logger.exception("Erro durante o healthcheck da API do Jira")
+            return False, str(e)

--- a/jiboia/core/service/jira_svc.py
+++ b/jiboia/core/service/jira_svc.py
@@ -5,16 +5,16 @@ from django.conf import settings
 logger = logging.getLogger(__name__)
 
 class JiraService:
-    """Serviço para interação com a API do Jira"""
+    """Service for Jira API integration"""
     
     @staticmethod
     def healthcheck():
         """
-        Realiza um healthcheck na API do Jira verificando o endpoint de projetos.
+        Performs a healthcheck on the Jira API by checking the projects endpoint.
         
         Returns:
-            tuple: (success, message) onde success é um booleano indicando se o healthcheck foi bem-sucedido
-                   e message é uma string com detalhes adicionais.
+            tuple: (success, message) where success is a boolean indicating if the healthcheck was successful
+                   and message is a string with additional details.
         """
         email = settings.JIRA_API_EMAIL
         token = settings.JIRA_API_TOKEN
@@ -22,7 +22,7 @@ class JiraService:
         
         url = f"{base_url}/rest/api/3/project"
         
-        logger.info(f"Realizando healthcheck na API do Jira: {url}")
+        logger.info(f"Performing Jira API healthcheck: {url}")
         
         try:
             response = requests.get(
@@ -33,12 +33,12 @@ class JiraService:
             
             if response.status_code == 200:
                 projects_count = len(response.json())
-                logger.info(f"Jira API healthcheck bem-sucedido. {projects_count} projetos encontrados.")
-                return True, f"OK - {projects_count} projetos encontrados"
+                logger.info(f"Jira API healthcheck successful. {projects_count} projects found.")
+                return True, f"OK - {projects_count} projects found"
             else:
-                logger.error(f"Jira API healthcheck falhou com status {response.status_code}: {response.text}")
-                return False, f"Falhou com status {response.status_code}"
+                logger.error(f"Jira API healthcheck failed with status {response.status_code}: {response.text}")
+                return False, f"Failed with status {response.status_code}"
                 
         except Exception as e:
-            logger.exception("Erro durante o healthcheck da API do Jira")
+            logger.exception("Error during Jira API healthcheck")
             return False, str(e)

--- a/jiboia/core/tests/__init__.py
+++ b/jiboia/core/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+Arquivo de inicialização do pacote de testes.
+"""

--- a/jiboia/core/tests/conftest.py
+++ b/jiboia/core/tests/conftest.py
@@ -1,0 +1,4 @@
+"""
+Configurações de teste para o módulo core.
+"""
+import pytest

--- a/jiboia/core/tests/test_cron.py
+++ b/jiboia/core/tests/test_cron.py
@@ -1,6 +1,3 @@
-"""
-Testes para as funções de cron jobs.
-"""
 import pytest
 from unittest.mock import patch, MagicMock
 from freezegun import freeze_time
@@ -10,37 +7,24 @@ from jiboia.core.cron import jira_healthcheck
 
 
 class TestCronJobs:
-    """Testes para as funções de cron jobs."""
 
     @freeze_time("2025-09-19 00:00:01")
     @patch('jiboia.core.cron.JiraService.healthcheck')
     def test_jira_healthcheck_success(self, mock_healthcheck):
-        """
-        Testa o caso de sucesso da função de cron jira_healthcheck.
-        """
-        # Configurar o mock para simular um healthcheck bem-sucedido
-        mock_healthcheck.return_value = (True, "OK - 5 projetos encontrados")
+        mock_healthcheck.return_value = (True, "OK - 5 projects found")
 
-        # Executar a função de cron
         result = jira_healthcheck()
 
-        # Verificar o resultado
         assert result is True
         mock_healthcheck.assert_called_once()
 
     @freeze_time("2025-09-19 00:00:01")
     @patch('jiboia.core.cron.JiraService.healthcheck')
     def test_jira_healthcheck_failure(self, mock_healthcheck):
-        """
-        Testa o caso de falha da função de cron jira_healthcheck.
-        """
-        # Configurar o mock para simular um healthcheck com falha
-        mock_healthcheck.return_value = (False, "Falhou com status 500")
+        mock_healthcheck.return_value = (False, "Failed with status 500")
 
-        # Executar a função de cron
         result = jira_healthcheck()
 
-        # Verificar o resultado
         assert result is False
         mock_healthcheck.assert_called_once()
 
@@ -48,54 +32,36 @@ class TestCronJobs:
     @patch('jiboia.core.cron.JiraService.healthcheck')
     @patch('jiboia.core.cron.logger')
     def test_jira_healthcheck_logging_success(self, mock_logger, mock_healthcheck):
-        """
-        Testa se os logs são registrados corretamente em caso de sucesso.
-        """
-        # Configurar o mock para simular um healthcheck bem-sucedido
-        mock_healthcheck.return_value = (True, "OK - 5 projetos encontrados")
+        mock_healthcheck.return_value = (True, "OK - 5 projects found")
 
-        # Executar a função de cron
         jira_healthcheck()
 
-        # Verificar se os logs foram registrados corretamente
         assert mock_logger.info.call_count == 2
         mock_logger.error.assert_not_called()
         
-        # Verificar a primeira chamada (início do healthcheck)
         mock_logger.info.assert_any_call(
-            '[CRON] Iniciando healthcheck da API do Jira em 2025-09-19 00:00:01'
+            '[CRON] Starting Jira API healthcheck at 2025-09-19 00:00:01'
         )
         
-        # Verificar a segunda chamada (fim do healthcheck)
-        # Como estamos usando freeze_time, duration será 0
         mock_logger.info.assert_any_call(
-            '[CRON] Healthcheck da API do Jira concluído com sucesso em 0.00s: OK - 5 projetos encontrados'
+            '[CRON] Jira API healthcheck completed successfully in 0.00s: OK - 5 projects found'
         )
 
     @freeze_time("2025-09-19 00:00:01")
     @patch('jiboia.core.cron.JiraService.healthcheck')
     @patch('jiboia.core.cron.logger')
     def test_jira_healthcheck_logging_failure(self, mock_logger, mock_healthcheck):
-        """
-        Testa se os logs são registrados corretamente em caso de falha.
-        """
-        # Configurar o mock para simular um healthcheck com falha
-        mock_healthcheck.return_value = (False, "Falhou com status 500")
+        mock_healthcheck.return_value = (False, "Failed with status 500")
 
-        # Executar a função de cron
         jira_healthcheck()
 
-        # Verificar se os logs foram registrados corretamente
         assert mock_logger.info.call_count == 1
         assert mock_logger.error.call_count == 1
         
-        # Verificar a primeira chamada (início do healthcheck)
         mock_logger.info.assert_called_once_with(
-            '[CRON] Iniciando healthcheck da API do Jira em 2025-09-19 00:00:01'
+            '[CRON] Starting Jira API healthcheck at 2025-09-19 00:00:01'
         )
         
-        # Verificar a chamada de erro
-        # Como estamos usando freeze_time, duration será 0
         mock_logger.error.assert_called_once_with(
-            '[CRON] Healthcheck da API do Jira falhou após 0.00s: Falhou com status 500'
+            '[CRON] Jira API healthcheck failed after 0.00s: Failed with status 500'
         )

--- a/jiboia/core/tests/test_cron.py
+++ b/jiboia/core/tests/test_cron.py
@@ -1,0 +1,101 @@
+"""
+Testes para as funções de cron jobs.
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+from freezegun import freeze_time
+from datetime import datetime
+
+from jiboia.core.cron import jira_healthcheck
+
+
+class TestCronJobs:
+    """Testes para as funções de cron jobs."""
+
+    @freeze_time("2025-09-19 00:00:01")
+    @patch('jiboia.core.cron.JiraService.healthcheck')
+    def test_jira_healthcheck_success(self, mock_healthcheck):
+        """
+        Testa o caso de sucesso da função de cron jira_healthcheck.
+        """
+        # Configurar o mock para simular um healthcheck bem-sucedido
+        mock_healthcheck.return_value = (True, "OK - 5 projetos encontrados")
+
+        # Executar a função de cron
+        result = jira_healthcheck()
+
+        # Verificar o resultado
+        assert result is True
+        mock_healthcheck.assert_called_once()
+
+    @freeze_time("2025-09-19 00:00:01")
+    @patch('jiboia.core.cron.JiraService.healthcheck')
+    def test_jira_healthcheck_failure(self, mock_healthcheck):
+        """
+        Testa o caso de falha da função de cron jira_healthcheck.
+        """
+        # Configurar o mock para simular um healthcheck com falha
+        mock_healthcheck.return_value = (False, "Falhou com status 500")
+
+        # Executar a função de cron
+        result = jira_healthcheck()
+
+        # Verificar o resultado
+        assert result is False
+        mock_healthcheck.assert_called_once()
+
+    @freeze_time("2025-09-19 00:00:01")
+    @patch('jiboia.core.cron.JiraService.healthcheck')
+    @patch('jiboia.core.cron.logger')
+    def test_jira_healthcheck_logging_success(self, mock_logger, mock_healthcheck):
+        """
+        Testa se os logs são registrados corretamente em caso de sucesso.
+        """
+        # Configurar o mock para simular um healthcheck bem-sucedido
+        mock_healthcheck.return_value = (True, "OK - 5 projetos encontrados")
+
+        # Executar a função de cron
+        jira_healthcheck()
+
+        # Verificar se os logs foram registrados corretamente
+        assert mock_logger.info.call_count == 2
+        mock_logger.error.assert_not_called()
+        
+        # Verificar a primeira chamada (início do healthcheck)
+        mock_logger.info.assert_any_call(
+            '[CRON] Iniciando healthcheck da API do Jira em 2025-09-19 00:00:01'
+        )
+        
+        # Verificar a segunda chamada (fim do healthcheck)
+        # Como estamos usando freeze_time, duration será 0
+        mock_logger.info.assert_any_call(
+            '[CRON] Healthcheck da API do Jira concluído com sucesso em 0.00s: OK - 5 projetos encontrados'
+        )
+
+    @freeze_time("2025-09-19 00:00:01")
+    @patch('jiboia.core.cron.JiraService.healthcheck')
+    @patch('jiboia.core.cron.logger')
+    def test_jira_healthcheck_logging_failure(self, mock_logger, mock_healthcheck):
+        """
+        Testa se os logs são registrados corretamente em caso de falha.
+        """
+        # Configurar o mock para simular um healthcheck com falha
+        mock_healthcheck.return_value = (False, "Falhou com status 500")
+
+        # Executar a função de cron
+        jira_healthcheck()
+
+        # Verificar se os logs foram registrados corretamente
+        assert mock_logger.info.call_count == 1
+        assert mock_logger.error.call_count == 1
+        
+        # Verificar a primeira chamada (início do healthcheck)
+        mock_logger.info.assert_called_once_with(
+            '[CRON] Iniciando healthcheck da API do Jira em 2025-09-19 00:00:01'
+        )
+        
+        # Verificar a chamada de erro
+        # Como estamos usando freeze_time, duration será 0
+        mock_logger.error.assert_called_once_with(
+            '[CRON] Healthcheck da API do Jira falhou após 0.00s: Falhou com status 500'
+        )

--- a/jiboia/core/tests/test_jira_service.py
+++ b/jiboia/core/tests/test_jira_service.py
@@ -1,6 +1,3 @@
-"""
-Testes para o serviço JiraService que interage com a API do Jira.
-"""
 import pytest
 from unittest.mock import patch, MagicMock
 from requests.exceptions import RequestException, ConnectionError, Timeout
@@ -9,14 +6,9 @@ from jiboia.core.service.jira_svc import JiraService
 
 
 class TestJiraService:
-    """Testes para o serviço JiraService."""
 
     @patch('jiboia.core.service.jira_svc.requests.get')
     def test_healthcheck_success(self, mock_get):
-        """
-        Testa o caso de sucesso do healthcheck da API do Jira.
-        """
-        # Configurar o mock para simular uma resposta bem-sucedida
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.json.return_value = [
@@ -25,19 +17,14 @@ class TestJiraService:
         ]
         mock_get.return_value = mock_response
 
-        # Executar o healthcheck
         success, message = JiraService.healthcheck()
 
-        # Verificar o resultado
         assert success is True
-        assert "OK - 2 projetos encontrados" in message
+        assert "OK - 2 projects found" in message
         mock_get.assert_called_once()
 
     @patch('jiboia.core.service.jira_svc.requests.get')
     def test_healthcheck_empty_response(self, mock_get):
-        """
-        Testa o caso de sucesso com lista vazia de projetos.
-        """
         # Configurar o mock para simular uma resposta vazia
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -50,90 +37,71 @@ class TestJiraService:
         # Verificar o resultado
         assert success is True
         assert "OK - 0 projetos encontrados" in message
+    @patch('jiboia.core.service.jira_svc.requests.get')
+    def test_healthcheck_empty_response(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        success, message = JiraService.healthcheck()
+
+        assert success is True
+        assert "OK - 0 projects found" in message
         mock_get.assert_called_once()
 
     @patch('jiboia.core.service.jira_svc.requests.get')
     def test_healthcheck_http_error(self, mock_get):
-        """
-        Testa o caso de erro HTTP no healthcheck da API do Jira.
-        """
-        # Configurar o mock para simular uma resposta de erro
         mock_response = MagicMock()
         mock_response.status_code = 401
         mock_response.text = "Unauthorized"
         mock_get.return_value = mock_response
 
-        # Executar o healthcheck
         success, message = JiraService.healthcheck()
 
-        # Verificar o resultado
         assert success is False
-        assert "Falhou com status 401" in message
+        assert "Failed with status 401" in message
         mock_get.assert_called_once()
 
     @patch('jiboia.core.service.jira_svc.requests.get')
     def test_healthcheck_server_error(self, mock_get):
-        """
-        Testa o caso de erro de servidor no healthcheck da API do Jira.
-        """
-        # Configurar o mock para simular uma resposta de erro de servidor
         mock_response = MagicMock()
         mock_response.status_code = 500
         mock_response.text = "Internal Server Error"
         mock_get.return_value = mock_response
 
-        # Executar o healthcheck
         success, message = JiraService.healthcheck()
 
-        # Verificar o resultado
         assert success is False
-        assert "Falhou com status 500" in message
+        assert "Failed with status 500" in message
         mock_get.assert_called_once()
 
     @patch('jiboia.core.service.jira_svc.requests.get')
     def test_healthcheck_connection_error(self, mock_get):
-        """
-        Testa o caso de erro de conexão no healthcheck da API do Jira.
-        """
-        # Configurar o mock para simular um erro de conexão
-        mock_get.side_effect = ConnectionError("Falha na conexão")
+        mock_get.side_effect = ConnectionError("Connection failure")
 
-        # Executar o healthcheck
         success, message = JiraService.healthcheck()
 
-        # Verificar o resultado
         assert success is False
-        assert "Falha na conexão" in message
+        assert "Connection failure" in message
         mock_get.assert_called_once()
 
     @patch('jiboia.core.service.jira_svc.requests.get')
     def test_healthcheck_timeout(self, mock_get):
-        """
-        Testa o caso de timeout no healthcheck da API do Jira.
-        """
-        # Configurar o mock para simular um timeout
-        mock_get.side_effect = Timeout("Timeout na requisição")
+        mock_get.side_effect = Timeout("Request timeout")
 
-        # Executar o healthcheck
         success, message = JiraService.healthcheck()
 
-        # Verificar o resultado
         assert success is False
-        assert "Timeout na requisição" in message
+        assert "Request timeout" in message
         mock_get.assert_called_once()
 
     @patch('jiboia.core.service.jira_svc.requests.get')
     def test_healthcheck_generic_exception(self, mock_get):
-        """
-        Testa o caso de exceção genérica no healthcheck da API do Jira.
-        """
-        # Configurar o mock para simular uma exceção genérica
-        mock_get.side_effect = Exception("Erro inesperado")
+        mock_get.side_effect = Exception("Unexpected error")
 
-        # Executar o healthcheck
         success, message = JiraService.healthcheck()
 
-        # Verificar o resultado
         assert success is False
-        assert "Erro inesperado" in message
+        assert "Unexpected error" in message
         mock_get.assert_called_once()

--- a/jiboia/core/tests/test_jira_service.py
+++ b/jiboia/core/tests/test_jira_service.py
@@ -1,0 +1,139 @@
+"""
+Testes para o serviço JiraService que interage com a API do Jira.
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+from requests.exceptions import RequestException, ConnectionError, Timeout
+
+from jiboia.core.service.jira_svc import JiraService
+
+
+class TestJiraService:
+    """Testes para o serviço JiraService."""
+
+    @patch('jiboia.core.service.jira_svc.requests.get')
+    def test_healthcheck_success(self, mock_get):
+        """
+        Testa o caso de sucesso do healthcheck da API do Jira.
+        """
+        # Configurar o mock para simular uma resposta bem-sucedida
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {"id": "10000", "key": "PROJ1", "name": "Projeto 1"},
+            {"id": "10001", "key": "PROJ2", "name": "Projeto 2"}
+        ]
+        mock_get.return_value = mock_response
+
+        # Executar o healthcheck
+        success, message = JiraService.healthcheck()
+
+        # Verificar o resultado
+        assert success is True
+        assert "OK - 2 projetos encontrados" in message
+        mock_get.assert_called_once()
+
+    @patch('jiboia.core.service.jira_svc.requests.get')
+    def test_healthcheck_empty_response(self, mock_get):
+        """
+        Testa o caso de sucesso com lista vazia de projetos.
+        """
+        # Configurar o mock para simular uma resposta vazia
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        # Executar o healthcheck
+        success, message = JiraService.healthcheck()
+
+        # Verificar o resultado
+        assert success is True
+        assert "OK - 0 projetos encontrados" in message
+        mock_get.assert_called_once()
+
+    @patch('jiboia.core.service.jira_svc.requests.get')
+    def test_healthcheck_http_error(self, mock_get):
+        """
+        Testa o caso de erro HTTP no healthcheck da API do Jira.
+        """
+        # Configurar o mock para simular uma resposta de erro
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "Unauthorized"
+        mock_get.return_value = mock_response
+
+        # Executar o healthcheck
+        success, message = JiraService.healthcheck()
+
+        # Verificar o resultado
+        assert success is False
+        assert "Falhou com status 401" in message
+        mock_get.assert_called_once()
+
+    @patch('jiboia.core.service.jira_svc.requests.get')
+    def test_healthcheck_server_error(self, mock_get):
+        """
+        Testa o caso de erro de servidor no healthcheck da API do Jira.
+        """
+        # Configurar o mock para simular uma resposta de erro de servidor
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        mock_get.return_value = mock_response
+
+        # Executar o healthcheck
+        success, message = JiraService.healthcheck()
+
+        # Verificar o resultado
+        assert success is False
+        assert "Falhou com status 500" in message
+        mock_get.assert_called_once()
+
+    @patch('jiboia.core.service.jira_svc.requests.get')
+    def test_healthcheck_connection_error(self, mock_get):
+        """
+        Testa o caso de erro de conexão no healthcheck da API do Jira.
+        """
+        # Configurar o mock para simular um erro de conexão
+        mock_get.side_effect = ConnectionError("Falha na conexão")
+
+        # Executar o healthcheck
+        success, message = JiraService.healthcheck()
+
+        # Verificar o resultado
+        assert success is False
+        assert "Falha na conexão" in message
+        mock_get.assert_called_once()
+
+    @patch('jiboia.core.service.jira_svc.requests.get')
+    def test_healthcheck_timeout(self, mock_get):
+        """
+        Testa o caso de timeout no healthcheck da API do Jira.
+        """
+        # Configurar o mock para simular um timeout
+        mock_get.side_effect = Timeout("Timeout na requisição")
+
+        # Executar o healthcheck
+        success, message = JiraService.healthcheck()
+
+        # Verificar o resultado
+        assert success is False
+        assert "Timeout na requisição" in message
+        mock_get.assert_called_once()
+
+    @patch('jiboia.core.service.jira_svc.requests.get')
+    def test_healthcheck_generic_exception(self, mock_get):
+        """
+        Testa o caso de exceção genérica no healthcheck da API do Jira.
+        """
+        # Configurar o mock para simular uma exceção genérica
+        mock_get.side_effect = Exception("Erro inesperado")
+
+        # Executar o healthcheck
+        success, message = JiraService.healthcheck()
+
+        # Verificar o resultado
+        assert success is False
+        assert "Erro inesperado" in message
+        mock_get.assert_called_once()

--- a/jiboia/jiboia/settings.py
+++ b/jiboia/jiboia/settings.py
@@ -62,7 +62,7 @@ DJANGO_APPS = [
 
 THIRD_PARTY_APPS = [
     "django_extensions",
-    
+    "django_crontab",
 ]
 
 # CORS
@@ -257,3 +257,17 @@ LOGGING = {
 #     # make all loggers use the console.
 #     for logger in LOGGING['loggers']:
 #         LOGGING['loggers'][logger]['handlers'] = ['console']
+
+# Configurações da API do Jira
+JIRA_API_EMAIL = config("JIRA_API_EMAIL", default="")
+JIRA_API_TOKEN = config("JIRA_API_TOKEN", default="")
+JIRA_API_URL = config("JIRA_API_URL", default="https://necto.atlassian.net")
+
+# Configuração do django-crontab
+CRONJOBS = [
+    # Formato: ('minuto hora dia_do_mês mês dia_da_semana', 'caminho.para.função', ['argumentos opcionais'], {'kwargs opcionais'}, 'id_único')
+    ('0 0 * * *', 'jiboia.core.cron.jira_healthcheck', '>> /tmp/jira_healthcheck.log 2>&1', {}, 'jira_daily_healthcheck')
+]
+
+
+CRONTAB_COMMAND_PREFIX = 'DJANGO_SETTINGS_MODULE=jiboia.jiboia.settings'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "jiboia"
 version = "0.1.0"
-requires-python = "==3.11"
+requires-python = "~=3.11"
 dependencies = [
     "asgiref==3.8.1",
     "dj-database-url==2.2.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ ruff>=0.13.0
 pytest==8.3.3
 pytest-django==4.9.0
 mock==5.1.0
+freezegun==1.4.0
 
 # Better Dev Experience
 ipython==8.28.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,6 @@ python-decouple==3.8
 # PROD
 #uWSGI==2.0.21
 
+# CRON JOB
+django-crontab==0.7.1
+requests==2.31.0


### PR DESCRIPTION
Este PR implementa um cron job para realizar verificações de saúde noturnas na API do Jira. A implementação inclui:

* Adicionado django-crontab para agendar o cron job à meia-noite
* Criado jira-service com método de healthcheck para validar a conectividade da API
* Implementada função de cron para logging e tratamento de erros
* Adicionada configuração Docker para suportar a execução do cron
* Criados testes unitários abrangentes com respostas simuladas
* Adicionada documentação para a funcionalidade do cron job