### PR TITLE
fix(#192): fix pr stats generating chart in dev -> main

### DIFF
--- a/.github/workflows/collect-pr-stats.yml
+++ b/.github/workflows/collect-pr-stats.yml
@@ -26,7 +26,7 @@ jobs:
         run: echo '${{ steps.pr_stats.outputs.resultsJson }}' > pr-stats-data.json
 
       - name: Save PR stats artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pr-stats-data
           path: pr-stats-data.json

--- a/.github/workflows/generate-pr-chats-main.yml
+++ b/.github/workflows/generate-pr-chats-main.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Download PR stats artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: pr-stats-data
           path: ./pr-stats-data


### PR DESCRIPTION
O fix adiciona 2 workflows para captura e geração de métricas de PR.
A workflow "collect-pr-stats.yml", coleta os dados definidos dos últimos 30 dias de todos os PRs para a dev e armazena em um arquivo JSON.
A workflow "generate-pr-charts-main", usa os dados armazenados na outra workflow no arquivo JSON e gera a CHART no merge da DEV para MAIN.